### PR TITLE
fix: Use `is_scalar` instead of `is_string`

### DIFF
--- a/src/Classes/AjaxResponse.php
+++ b/src/Classes/AjaxResponse.php
@@ -563,6 +563,6 @@ class AjaxResponse implements Responsable
             return (string) $content;
         }
 
-        return is_string($content) ? $content : '';
+        return is_scalar($content) ? $content : '';
     }
 }


### PR DESCRIPTION
Replaced `is_string` with `is_scalar` (integer, float, string or boolean) to allow scalar values to be returned as a response.