### PR TITLE
Improve Exception Handling in AjaxResponse

### DIFF
--- a/src/Classes/AjaxResponse.php
+++ b/src/Classes/AjaxResponse.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Illuminate\Http\Response as HttpResponse;
 
 /**
  * AjaxResponse class returned from ajax() call
@@ -511,7 +512,19 @@ class AjaxResponse implements Responsable
         }
 
         if ($exception instanceof \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException) {
-            return $this->error('Access Denied');
+            return $this->error('Access Denied', 403);
+        }
+
+        if ($exception instanceof \Illuminate\Database\Eloquent\ModelNotFoundException) {
+            return $this->error($exception->getMessage(), 404);
+        }
+
+        if ($exception instanceof \Symfony\Component\HttpKernel\Exception\HttpException) {
+            $status = $exception->getStatusCode();
+            return $this->error(
+                $exception->getMessage() ?: (HttpResponse::$statusTexts[$status] ?? 'Whoops, looks like something went wrong.'),
+                $status
+            );
         }
 
         if ($exception instanceof \Illuminate\Database\QueryException) {


### PR DESCRIPTION
This update enhances the exception handling within the AjaxResponse class to provide more specific and appropriate HTTP responses for various error conditions.

 - Adds handling for ModelNotFoundException to return a 404 response.
 - Adds handling for generic HttpException, returning the corresponding status code and message.
 - Updates AccessDeniedHttpException handling to return a 403 status code.