### PR TITLE
Keep loading indicators visible while redirect navigation is pending

### DIFF
--- a/resources/src/request/actions.js
+++ b/resources/src/request/actions.js
@@ -299,12 +299,14 @@ export class Actions
             turboVisit(href);
         }
         else {
+            this.delegate.requestRedirecting();
             location.assign(href);
         }
     }
 
     // Custom function, reload the browser
     handleReloadResponse() {
+        this.delegate.requestRedirecting();
         location.reload();
     }
 

--- a/resources/src/request/request.js
+++ b/resources/src/request/request.js
@@ -304,6 +304,21 @@ export class Request
         }
     }
 
+    // Restores loading indicators while a full-page navigation is pending,
+    // since requestFinished hides them before the browser leaves the page.
+    // The pageshow listener cleans up when the page is restored from the
+    // back/forward cache instead of being unloaded.
+    requestRedirecting() {
+        this.markAsProgress(true);
+        this.toggleLoadingElement(true);
+
+        if (this.options.progressBar) {
+            this.showProgressBar();
+        }
+
+        window.addEventListener('pageshow', () => this.requestFinished(), { once: true });
+    }
+
     // Private
     initOtherElements() {
         if (typeof this.options.form === 'string') {


### PR DESCRIPTION
On an AJAX response that redirects (or reloads), the loading indicators disappear before the browser actually leaves the page, so the user stares at an idle page for the whole navigation gap (up to seconds on slow connections) with no feedback.

Two things cause it:

- `handleResponse` calls `requestCompletedWithResponse(...)` without awaiting it, then calls `this.destroy()` -> `requestFinished()`. The success action chain (which eventually reaches `handleRedirectResponse`) suspends at its first await, so the `data-request-loading` element and the progress bar are hidden before `location.assign()` even runs.
- Even with the ordering fixed, `location.assign()` / `location.reload()` don't unload the page synchronously - indicators need to stay up until the page is actually left.

Fix: `handleRedirectResponse` (non-turbo branch) and `handleReloadResponse` now call a new `Request.requestRedirecting()` delegate method that re-enables the indicators (`data-ajax-progress`, the loading element, the progress bar) for the remainder of the page's life. A `{ once: true }` `pageshow` listener calls `requestFinished()` so a page restored from the back/forward cache comes back clean instead of showing a stuck indicator.

The turbo path is left alone: `turboVisit()` swaps the DOM in place and has its own progress handling, and keeping indicators up would contaminate the turbo snapshot used for back navigation.

Repro: any handler returning `Redirect::to(...)` from a `data-request` element with `data-request-loading` (or with the progress bar enabled), ideally with network throttling - the indicator blinks off the moment the response arrives, then the old page sits idle until the new one loads.

Source-only change; happy to rebuild dist if you prefer that included.
