### PR TITLE
Hide attach loaders when page is restored from bfcache

### DIFF
--- a/resources/src/extras/controller.js
+++ b/resources/src/extras/controller.js
@@ -28,7 +28,9 @@ export class Controller
         };
 
         this.hideAllAttachLoaders = (event) => {
-            this.attachLoader.hideAll();
+            if (event.persisted) {
+                this.attachLoader.hideAll();
+            }
         };
 
         // Validator
@@ -127,6 +129,7 @@ export class Controller
             Events.on(document, 'ajax:promise', 'form, [data-attach-loading]', this.showAttachLoader);
             Events.on(document, 'ajax:fail', 'form, [data-attach-loading]', this.hideAttachLoader);
             Events.on(document, 'ajax:done', 'form, [data-attach-loading]', this.hideAttachLoader);
+            addEventListener('pageshow', this.hideAllAttachLoaders);
 
             // Validator
             this.validator = new Validator;
@@ -155,6 +158,7 @@ export class Controller
             Events.off(document, 'ajax:promise', 'form, [data-attach-loading]', this.showAttachLoader);
             Events.off(document, 'ajax:fail', 'form, [data-attach-loading]', this.hideAttachLoader);
             Events.off(document, 'ajax:done', 'form, [data-attach-loading]', this.hideAttachLoader);
+            removeEventListener('pageshow', this.hideAllAttachLoaders);
 
             // Validator
             this.validator = null;


### PR DESCRIPTION
Follow-up to #14, which keeps loaders visible through a redirect and cleans up the loading element and progress bar on `pageshow`. The attach loader misses that cleanup: after a server redirect + browser Back, submit buttons stay `disabled` with `.jax-attach-loader` until a manual reload.

Cause: a server redirect sets `isRedirect` via `toggleRedirect()`, so the `.then`/`.catch` guards in `Request.start()` skip `ajax:done`/`ajax:fail` — correct while navigating (the spinner should persist), but those are the only events that hide the attach loader, and nothing restores it when the page comes back from the back/forward cache. Present in 2.2.3 as well, not a regression from #14.

Fix: bind the existing (previously unbound) `hideAllAttachLoaders` handler to `pageshow`, gated on `event.persisted` so it only acts on bfcache restores. `bun test` passes (330).